### PR TITLE
Bug fixes, optimizations and a new task type

### DIFF
--- a/asyncrunner/DelayedTask.hx
+++ b/asyncrunner/DelayedTask.hx
@@ -50,6 +50,12 @@ class DelayedTask extends Task
         taskToDelay.onFailure.add(this.onFailure.dispatch);
     }
 
+	private function cleanup(): Void
+	{
+		task.onFinish.remove(this.onFinish.dispatch);
+        task.onFailure.remove(this.onFailure.dispatch);
+	}
+
     override function subclassExecute(): Void
     {
         RunLoop.getMainLoop().delay(task.execute, delaySeconds);
@@ -63,16 +69,19 @@ class DelayedTask extends Task
     override public function cancel(): Void
     {
         task.cancel();
+		cleanup();
     }
 
     override public function fail(?failureCode: Int, ?failureMessage: String): Void
     {
         task.fail();
+		cleanup();
     }
 
     override public function finish(): Void
     {
         task.finish();
+		cleanup();
     }
 
     override public function isPending(): Bool

--- a/asyncrunner/FunctionWrapperTask.hx
+++ b/asyncrunner/FunctionWrapperTask.hx
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2003-2016, GameDuell GmbH
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package asyncrunner;
+
+import asyncrunner.TaskCategoryID;
+import asyncrunner.Task;
+
+class FunctionWrapperTask extends Task
+{
+    private var func: Void -> Task;
+    public function new(func: Void -> Task, category: TaskCategoryID = 0): Void
+    {
+        super(category);
+
+        this.func = func;
+    }
+
+    override function subclassExecute(): Void
+    {
+        runLoopForExecution.queue(executeFuncAndExit.bind(true), priorityForExecution);
+    }
+
+    override function executeSynchronous(): Void
+    {
+        executeFuncAndExit(true);
+    }
+
+    private function executeFuncAndExit(synchronous: Bool): Void
+    {
+        switch(result)
+        {
+            case TaskResultCancelled,
+                 TaskResultFailed(_, _),
+                 TaskResultSuccessful:
+                return;
+            case TaskResultPending:
+
+                var task = func();
+
+                task.onFinish.addOnce(taskFinished);
+                task.onFailure.addOnce(taskFailed);
+                if (synchronous)
+                {
+                    task.executeSynchronous();
+                }
+                else
+                {
+                    task.execute();
+                }
+
+                return;
+        }
+    }
+
+    private function taskFailed(task : Task) : Void
+    {
+        switch (task.result)
+        {
+            case TaskResultFailed(failureCode, failureMessage):
+            {
+                fail(failureCode, failureMessage);
+            }
+            default:
+                throw "Incorrect internal state of asyncrunner, task called failed, when it wasn't";
+        }
+    }
+
+    private function taskFinished(task : Task) : Void
+    {
+        finish();
+    }
+
+    override function set_result(newResult: TaskResult): TaskResult
+    {
+        switch ([result, newResult])
+        {
+            case [TaskResultPending, _]:
+                result = newResult;
+            default:
+                throw "Incorrect state on task, task result should only go from pending to any other state";
+        }
+
+        switch(result)
+        {
+            case TaskResultPending:
+            default:
+                func = null;
+        }
+
+        return result;
+    }
+}

--- a/asyncrunner/ParallelTaskGroup.hx
+++ b/asyncrunner/ParallelTaskGroup.hx
@@ -78,6 +78,12 @@ class ParallelTaskGroup extends Task
 
     override function subclassExecute() : Void
     {
+        if (tasksLeft.length == 0)
+        {
+            finish();
+            return;
+        }
+        
         for(task in tasksLeft)
         {
             task.onFinish.addOnce(taskFinished);

--- a/asyncrunner/SequentialTaskGroup.hx
+++ b/asyncrunner/SequentialTaskGroup.hx
@@ -98,9 +98,10 @@ class SequentialTaskGroup extends Task
 
     override function executeSynchronous(): Void
     {
-        for (taskIndex in 0...taskQueue.length)
+        var taskIndex = 0;
+        while (taskIndex < taskQueue.length)
         {
-            var task = taskQueue[taskIndex];
+            var task = taskQueue[taskIndex++];
 
             task.executeSynchronous();
 

--- a/asyncrunner/SequentialTaskGroup.hx
+++ b/asyncrunner/SequentialTaskGroup.hx
@@ -83,7 +83,8 @@ class SequentialTaskGroup extends Task
 
         currentTask.onFinish.addOnce(taskFinished);
         currentTask.onFailure.addOnce(taskFailed);
-        runLoopForExecution.queue(currentTask.execute, priorityForExecution);
+
+        currentTask.execute();
     }
 
     override function cancel(): Void
@@ -128,7 +129,7 @@ class SequentialTaskGroup extends Task
     {
         currentTaskIndex = 0;
 
-        if(taskQueue.length == 0)
+        if (taskQueue.length == 0)
         {
             finish();
         }

--- a/asyncrunner/Task.hx
+++ b/asyncrunner/Task.hx
@@ -148,10 +148,10 @@ class Task
     {
         if (isCallbacksEnabled())
         {
-            runLoopForFinishing.queue(function() {
+            queueForFinishingIfNeeded(function() {
                 onFinish.dispatch(this);
                 cleanUpCallbacks();
-            }, priorityForFinishing);
+            });
         }
         else
         {
@@ -164,10 +164,10 @@ class Task
     {
         if (isCallbacksEnabled())
         {
-            runLoopForFinishing.queue(function() {
+            queueForFinishingIfNeeded(function() {
                 onFailure.dispatch(this);
                 cleanUpCallbacks();
-            }, priorityForFinishing);
+            });
         }
         else
         {
@@ -179,14 +179,26 @@ class Task
     {
         if (isCallbacksEnabled())
         {
-            runLoopForFinishing.queue(function() {
+            queueForFinishingIfNeeded(function() {
                 onCancelled.dispatch(this);
-                cleanUpCallbacks(); 
-            }, priorityForFinishing);
+                cleanUpCallbacks();
+            });
         }
         else
         {
             cleanUpCallbacks();
+        }
+    }
+
+    private function queueForFinishingIfNeeded(func: Void -> Void)
+    {
+        if (runLoopForExecution == runLoopForFinishing)
+        {
+            func();
+        }
+        else
+        {
+            runLoopForFinishing.queue(func, priorityForFinishing);
         }
     }
 


### PR DESCRIPTION
Added FunctionWrapperTask that lets a function return a sub task that is then executed. Useful if on a sequence you have a step that creates a dynamic sub task.

sequential task group not queuing each action twice, task just queues the finishing if the runloop for execution and finishing are different

Cleaned up signals.

Fixed bug where parallel task group never finishes if task list is empty
