### PR TITLE
subclassExecuteSynchronous and TaskNotStarted added to task result

### DIFF
--- a/asyncrunner/BlockingTask.hx
+++ b/asyncrunner/BlockingTask.hx
@@ -47,22 +47,10 @@ class BlockingTask extends Task
 
         if (executeCalled)
         {
-            callFinish();
-        }
-    }
-
-    private function callFinish(): Void
-    {
-        switch(result)
-        {
-            case TaskResultCancelled,
-                 TaskResultFailed(_, _),
-                 TaskResultSuccessful:
-                return;
-            case TaskResultPending:
-
+            if (result == TaskResultPending)
+            {
                 finish();
-                return;
+            }
         }
     }
 
@@ -71,16 +59,16 @@ class BlockingTask extends Task
         executeCalled = true;
         if (!blocked)
         {
-            callFinish();
+            finish();
         }
     }
 
-    override function executeSynchronous(): Void
+    override function subclassExecuteSynchronous(): Void
     {
         executeCalled = true;
         if (!blocked)
         {
-            callFinish();
+            finish();
         }
     }
 }

--- a/asyncrunner/BlockingTask.hx
+++ b/asyncrunner/BlockingTask.hx
@@ -31,8 +31,10 @@ import asyncrunner.Task;
 
 class BlockingTask extends Task
 {
-    private var blocked: Bool;
+    public var blocked (default, null): Bool;
+
     private var executeCalled: Bool;
+
     public function new(): Void
     {
         super(category);

--- a/asyncrunner/DelayedTask.hx
+++ b/asyncrunner/DelayedTask.hx
@@ -58,12 +58,12 @@ class DelayedTask extends Task
 
     override function subclassExecute(): Void
     {
-        RunLoop.getMainLoop().delay(task.execute, delaySeconds);
+        RunLoop.getMainLoop().delay(task.subclassExecute, delaySeconds);
     }
 
-    override function executeSynchronous(): Void
+    override function subclassExecuteSynchronous(): Void
     {
-        task.executeSynchronous();
+        task.subclassExecuteSynchronous();
     }
 
     override public function cancel(): Void

--- a/asyncrunner/FunctionTask.hx
+++ b/asyncrunner/FunctionTask.hx
@@ -46,45 +46,31 @@ class FunctionTask extends Task
         runLoopForExecution.queue(executeFuncAndExit, priorityForExecution);
     }
 
-    override function executeSynchronous(): Void
+    override function subclassExecuteSynchronous(): Void
     {
         executeFuncAndExit();
     }
 
     private function executeFuncAndExit(): Void
     {
-        switch(result)
+        func();
+
+        if(callFinish)
         {
-            case TaskResultCancelled,
-                 TaskResultFailed(_, _),
-                 TaskResultSuccessful:
-                return;
-            case TaskResultPending:
-
-                func();
-
-                if(callFinish)
-                {
-                    finish();
-                }
-
-                return;
+            finish();
         }
+
+        return;
     }
 
     override function set_result(newResult: TaskResult): TaskResult
     {
-        switch ([result, newResult])
-        {
-            case [TaskResultPending, _]:
-                result = newResult;
-            default:
-                throw "Incorrect state on task, task result should only go from pending to any other state";
-        }
+        super.set_result(newResult);
 
         switch(result)
         {
-            case TaskResultPending:
+            case TaskResultPending,
+                 TaskResultNotStarted:
             default:
                 func = null;
         }

--- a/asyncrunner/FunctionTask.hx
+++ b/asyncrunner/FunctionTask.hx
@@ -53,7 +53,10 @@ class FunctionTask extends Task
 
     private function executeFuncAndExit(): Void
     {
-        func();
+        if (func != null)
+        {
+            func();
+        }
 
         if(callFinish)
         {

--- a/asyncrunner/ParallelTaskGroup.hx
+++ b/asyncrunner/ParallelTaskGroup.hx
@@ -83,7 +83,7 @@ class ParallelTaskGroup extends Task
             finish();
             return;
         }
-        
+
         for(task in tasksLeft)
         {
             task.onFinish.addOnce(taskFinished);
@@ -92,7 +92,7 @@ class ParallelTaskGroup extends Task
         }
     }
 
-    override function executeSynchronous(): Void
+    override function subclassExecuteSynchronous(): Void
     {
         for (taskIndex in 0...tasksLeft.length)
         {

--- a/asyncrunner/SequentialTaskGroup.hx
+++ b/asyncrunner/SequentialTaskGroup.hx
@@ -97,7 +97,7 @@ class SequentialTaskGroup extends Task
         super.cancel();
     }
 
-    override function executeSynchronous(): Void
+    override function subclassExecuteSynchronous(): Void
     {
         var taskIndex = 0;
         while (taskIndex < taskQueue.length)

--- a/asyncrunner/SteppedTaskGroup.hx
+++ b/asyncrunner/SteppedTaskGroup.hx
@@ -1,0 +1,80 @@
+package asyncrunner;
+
+import asyncrunner.Task;
+
+class SteppedTaskGroup extends SequentialTaskGroup
+{
+    public var stepTasks (default, null): Array<Task>;
+
+    private var blockingTasks: Array<BlockingTask>;
+    private var currentStepIndex: Int;
+
+    public function new(tasks: Array<Task>) : Void
+    {
+        currentStepIndex = 0;
+        stepTasks = [];
+        blockingTasks = [];
+
+        var tasksToRun: Array<Task> = [];
+        for (i in 0 ... tasks.length)
+        {
+            stepTasks[i] = tasks[i];
+            tasksToRun.push(stepTasks[i]);
+
+            blockingTasks[i] = new BlockingTask();
+            tasksToRun.push(blockingTasks[i]);
+        }
+
+        super(tasksToRun);
+    }
+
+    override public function cancel(): Void
+    {
+        currentStepIndex = 0;
+
+        super.cancel();
+    }
+
+    override public function fail(?failureCode: Int, ?failureMessage: String): Void
+    {
+        currentStepIndex = 0;
+
+        super.fail(failureCode, failureMessage);
+    }
+
+    override public function finish(): Void
+    {
+        currentStepIndex = 0;
+
+        super.finish();
+    }
+
+    public function unblockAllSteps(): Void
+    {
+        for (i in 0 ... blockingTasks.length)
+        {
+            blockingTasks[i].unblock();
+        }
+    }
+
+    public function unblockStepAtIndex(index: Int): Void
+    {
+        if (index >= blockingTasks.length)
+        {
+            return;
+        }
+
+        blockingTasks[index].unblock();
+    }
+
+    public function unblockNextStep(): Void
+    {
+        if (currentStepIndex >= blockingTasks.length)
+        {
+            return;
+        }
+
+        blockingTasks[currentStepIndex].unblock();
+        ++currentStepIndex;
+    }
+}

--- a/asyncrunner/SteppedTaskGroup.hx
+++ b/asyncrunner/SteppedTaskGroup.hx
@@ -28,27 +28,6 @@ class SteppedTaskGroup extends SequentialTaskGroup
         super(tasksToRun);
     }
 
-    override public function cancel(): Void
-    {
-        currentStepIndex = 0;
-
-        super.cancel();
-    }
-
-    override public function fail(?failureCode: Int, ?failureMessage: String): Void
-    {
-        currentStepIndex = 0;
-
-        super.fail(failureCode, failureMessage);
-    }
-
-    override public function finish(): Void
-    {
-        currentStepIndex = 0;
-
-        super.finish();
-    }
-
     public function unblockAllSteps(): Void
     {
         for (i in 0 ... blockingTasks.length)

--- a/asyncrunner/TaskResult.hx
+++ b/asyncrunner/TaskResult.hx
@@ -28,6 +28,7 @@ package asyncrunner;
 
 enum TaskResult
 {
+	TaskResultNotStarted;
 	TaskResultPending;
 	TaskResultCancelled;
 	TaskResultFailed(failureCode: Int, failureMessage: String);


### PR DESCRIPTION
To improve writing and using tasks, we've added:
 - subclassExecuteSynchronous - we already had subclassExecute, and the point of it is to have the superClass check the state of the task before the subclass does it's operation. It makes sense to have the same for subclassExecuteSynchronous, since that check was being done in many subclasses anyway. 
 - TaskNotStarted - Before, a task started as TaskPending. Now it starts as TaskNotStarted, and when execute is called, it changes to TaskPending. This is better to safely cancel tasks that haven't been started yet, and letting tasks that are pending, finish up normally.

This is a major so you will have to make the existing compatible. Tell me if you have any problems.